### PR TITLE
Update main.cfg

### DIFF
--- a/config/IguanaTinkerTweaks/main.cfg
+++ b/config/IguanaTinkerTweaks/main.cfg
@@ -179,13 +179,11 @@ toolleveling {
     B:CompletelyRandomBonuses=false
 
     # The amount of modifiers new tools have. [range: 0 ~ 9, default: 0]
-    I:ExtraModifiers=0
+    I:ExtraModifiers=3
 
     # Adds an extra modifier on these levelups if 'ExtraModifiers' is enabled
     I:ModifiersAtLevels <
-        2
-        4
-        6
+    
      >
 
     # Gives a random bonus every level, if false and levelling is on modifiers are given at levels 2 and 4 (requires 'toolLeveling=true') [default: true]
@@ -216,13 +214,13 @@ toolleveling {
     S:xpPerBoostLevelMultiplier=1.12
 
     # Exponential multiplier for required xp per level [range: 1.0 ~ 9.99, default: 1.15]
-    S:xpPerLevelMultiplier=1.15
+    S:xpPerLevelMultiplier=1.7
 
     # Change the XP required to level up tools in % (higher = more xp needed) [range: 1 ~ 999, default: 100]
-    I:xpRequiredToolsPercentage=150
+    I:xpRequiredToolsPercentage=100
 
     # Change the XP required to level up weapons in % (higher = more xp needed) [range: 1 ~ 999, default: 100]
-    I:xpRequiredWeaponsPercentage=150
+    I:xpRequiredWeaponsPercentage=100
 }
 
 


### PR DESCRIPTION
Having all (3) modifier available on tool-creation, removing the added modifier slots upon leveling.
Also increased the xp needed for leveling quite a bit, which is only needed for random modifiers.